### PR TITLE
Make container monitor acme.json and runt dumpcerts.sh every time something changes

### DIFF
--- a/dumpcerts/Dockerfile
+++ b/dumpcerts/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine:latest
 
-RUN apk add --no-cache bash util-linux openssl jq
+RUN apk add --no-cache bash util-linux openssl jq inotify-tools
 RUN wget https://raw.githubusercontent.com/containous/traefik/master/contrib/scripts/dumpcerts.sh && \
     chmod +x dumpcerts.sh
+COPY ["monitor-acme-file-for-changes", "./monitor-acme-file-for-changes"]
+RUN chmod +x ./monitor-acme-file-for-changes
 
-CMD ["./dumpcerts.sh", "/in/acme.json", "/out/"]
+CMD ["./monitor-acme-file-for-changes", "/in/acme.json", "/out"]

--- a/dumpcerts/README.md
+++ b/dumpcerts/README.md
@@ -2,12 +2,12 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/deluca/dumpcerts.svg)](https://hub.docker.com/r/deluca/dumpcerts/)
 
-See https://github.com/containous/traefik/blob/master/contrib/scripts/dumpcerts.sh
+This container will monitor acme.json file for changes and run dumpcerts.sh if it happens. The container is using dumpcerts.sh from https://github.com/containous/traefik/blob/master/contrib/scripts/dumpcerts.sh
 
 ## Usage
 ```sh
 docker run -it --rm \
   -v $(pwd)/acme.json:/in/acme.json \
-  -v $(pwd)/out:/out/
+  -v $(pwd)/out:/out
   deluca/dumpcerts
 ```

--- a/dumpcerts/monitor-acme-file-for-changes
+++ b/dumpcerts/monitor-acme-file-for-changes
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+while true :; do
+  inotifywait --event modify "${1}"
+  sleep 2
+  ./dumpcerts.sh "${1}" "${2}"
+done


### PR DESCRIPTION
Monitor acme.json file for changes and run dumpcerts.sh every time a change is happens. The while true statement will make the container run forever until explicit stopped or killed.